### PR TITLE
[ELMS-22] Add Comment When Approving/Rejecting

### DIFF
--- a/XinNghiPhep/.gitignore
+++ b/XinNghiPhep/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+.smarttomcat/
+target/
+
+seed_sample_data.sql
+
+*.log
+*.tmp
+*.bak

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
@@ -118,12 +118,17 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
         EntityManager em = JPAConfig.getEntityManager();
         try {
             return em.createQuery(
-                    "SELECT lr FROM LeaveRequest lr WHERE lr.id = :id AND lr.user.id = :uid",
-                    LeaveRequest.class
+                    "SELECT lr, la.note FROM LeaveRequest lr "
+                            + "LEFT JOIN LeaveApproval la ON la.leaveRequest.id = lr.id "
+                            + "WHERE lr.id = :id AND lr.user.id = :uid",
+                    Object[].class
             )
             .setParameter("id", leaveId)
             .setParameter("uid", userId)
-            .getSingleResult();
+            .getResultStream()
+            .findFirst()
+            .map(this::mapLeaveRequestWithReviewComment)
+            .orElse(null);
         } catch (NoResultException e) {
             return null;
         } finally {
@@ -167,7 +172,17 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
     public LeaveRequest findById(int leaveId) {
         EntityManager em = JPAConfig.getEntityManager();
         try {
-            return em.find(LeaveRequest.class, leaveId);
+            return em.createQuery(
+                    "SELECT lr, la.note FROM LeaveRequest lr "
+                            + "LEFT JOIN LeaveApproval la ON la.leaveRequest.id = lr.id "
+                            + "WHERE lr.id = :id",
+                    Object[].class
+            )
+            .setParameter("id", leaveId)
+            .getResultStream()
+            .findFirst()
+            .map(this::mapLeaveRequestWithReviewComment)
+            .orElse(null);
         } finally {
             em.close();
         }
@@ -211,11 +226,16 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
         EntityManager em = JPAConfig.getEntityManager();
         try {
             return em.createQuery(
-                    "SELECT lr FROM LeaveRequest lr WHERE lr.id = :id AND lr.user.role = 'EMPLOYEE'",
-                    LeaveRequest.class
+                    "SELECT lr, la.note FROM LeaveRequest lr "
+                            + "LEFT JOIN LeaveApproval la ON la.leaveRequest.id = lr.id "
+                            + "WHERE lr.id = :id AND lr.user.role = 'EMPLOYEE'",
+                    Object[].class
             )
             .setParameter("id", leaveId)
-            .getSingleResult();
+            .getResultStream()
+            .findFirst()
+            .map(this::mapLeaveRequestWithReviewComment)
+            .orElse(null);
         } catch (NoResultException e) {
             return null;
         } finally {
@@ -416,12 +436,16 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
     private List<LeaveRequest> mapLeaveRequestsWithReviewComment(List<Object[]> rows) {
         List<LeaveRequest> result = new ArrayList<>(rows.size());
         for (Object[] row : rows) {
-            LeaveRequest leaveRequest = (LeaveRequest) row[0];
-            String reviewerComment = (String) row[1];
-            leaveRequest.setReviewerComment(reviewerComment);
-            result.add(leaveRequest);
+            result.add(mapLeaveRequestWithReviewComment(row));
         }
         return result;
+    }
+
+    private LeaveRequest mapLeaveRequestWithReviewComment(Object[] row) {
+        LeaveRequest leaveRequest = (LeaveRequest) row[0];
+        String reviewerComment = (String) row[1];
+        leaveRequest.setReviewerComment(reviewerComment);
+        return leaveRequest;
     }
 
     private int calculateRequestedDays(LeaveRequest leaveRequest) {

--- a/XinNghiPhep/src/main/webapp/view/leave/detail.jsp
+++ b/XinNghiPhep/src/main/webapp/view/leave/detail.jsp
@@ -41,6 +41,10 @@
 				<th>Reason</th>
 				<td>${leaveRequest.reason}</td>
 			</tr>
+			<tr>
+				<th>Comment</th>
+				<td>${empty leaveRequest.reviewerComment ? '-' : leaveRequest.reviewerComment}</td>
+			</tr>
 		</table>
 
 		<c:if test="${(sessionScope.account.role == 'MANAGER' || sessionScope.account.role == 'SUPER_ADMIN') && leaveRequest.status == 'PENDING'}">


### PR DESCRIPTION
## Summary
Implement comment feature when approving/rejecting leave request for Manager.

## Changes
- Add comment input when manager approves or rejects leave request
- Save comment to database in `LeaveApprovals.note`
- Reuse existing approve/reject flow in controller, service, and dao
- Load reviewer comment in leave request list
- Load reviewer comment in leave request detail
- Employee can see manager comment after request is processed
- Keep comment optional if manager does not enter anything

## Testing
- Manager enters comment and approves request
- Manager enters comment and rejects request
- Comment is shown in leave request list
- Employee can view comment in leave status/detail page
- Data saved correctly in database

## Evidence
- Verified in database (`LeaveApprovals` table)
- Verified by logging in as manager and employee

## Jira
ELMS-22
Closes #32