### PR TITLE
[ELMS-25] View Total Leave Statistics

### DIFF
--- a/XinNghiPhep/src/main/java/nhom13/vn/controller/AdminLeaveStatisticsController.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/controller/AdminLeaveStatisticsController.java
@@ -1,0 +1,178 @@
+package nhom13.vn.controller;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.User;
+import nhom13.vn.service.ILeaveRequestService;
+import nhom13.vn.service.impl.LeaveRequestServiceImpl;
+
+@WebServlet("/admin/leave-statistics")
+public class AdminLeaveStatisticsController extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ILeaveRequestService leaveRequestService = LeaveRequestServiceImpl.getInstance();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        User user = (User) req.getSession().getAttribute("account");
+        if (user == null) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        if (!"SUPER_ADMIN".equals(user.getRole())) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "You are not allowed to view leave statistics");
+            return;
+        }
+
+        LocalDate fromDate = parseDate(req.getParameter("fromDate"));
+        LocalDate toDate = parseDate(req.getParameter("toDate"));
+
+        if (fromDate != null && toDate != null && fromDate.isAfter(toDate)) {
+            req.setAttribute("error", "From date must be before or equal to To date.");
+            fromDate = null;
+            toDate = null;
+        }
+
+        final LocalDate filterFromDate = fromDate;
+        final LocalDate filterToDate = toDate;
+
+        List<LeaveRequest> filteredRequests = leaveRequestService.getAllForViewer(user, null)
+                .stream()
+                .filter(leaveRequest -> matchesDateRange(leaveRequest, filterFromDate, filterToDate))
+                .collect(Collectors.toList());
+
+        req.setAttribute("selectedFromDate", req.getParameter("fromDate"));
+        req.setAttribute("selectedToDate", req.getParameter("toDate"));
+        req.setAttribute("totalRequests", filteredRequests.size());
+        req.setAttribute("statusCounts", buildStatusCounts(filteredRequests));
+        req.setAttribute("leaveTypeCounts", buildLeaveTypeCounts(filteredRequests));
+        req.setAttribute("filteredLeaveRequests", filteredRequests);
+
+        req.getRequestDispatcher("/view/admin/leave-statistics.jsp").forward(req, resp);
+    }
+
+    private LocalDate parseDate(String rawDate) {
+        if (rawDate == null || rawDate.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(rawDate.trim());
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private boolean matchesDateRange(LeaveRequest leaveRequest, LocalDate fromDate, LocalDate toDate) {
+        if (leaveRequest == null || leaveRequest.getStartDate() == null) {
+            return false;
+        }
+
+        LocalDate requestDate = toLocalDate(leaveRequest.getStartDate());
+
+        if (fromDate != null && requestDate.isBefore(fromDate)) {
+            return false;
+        }
+
+        if (toDate != null && requestDate.isAfter(toDate)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private LocalDate toLocalDate(java.util.Date date) {
+        if (date instanceof java.sql.Date) {
+            return ((java.sql.Date) date).toLocalDate();
+        }
+
+        return date.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
+    }
+
+    private Map<String, Integer> buildStatusCounts(List<LeaveRequest> leaveRequests) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("PENDING", 0);
+        counts.put("APPROVED", 0);
+        counts.put("REJECTED", 0);
+        counts.put("CANCELLED", 0);
+
+        for (LeaveRequest leaveRequest : leaveRequests) {
+            String status = leaveRequest.getStatus();
+            if (counts.containsKey(status)) {
+                counts.put(status, counts.get(status) + 1);
+            }
+        }
+
+        return counts;
+    }
+
+    private Map<String, Integer> buildLeaveTypeCounts(List<LeaveRequest> leaveRequests) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("Sick Leave", 0);
+        counts.put("Personal Leave", 0);
+        counts.put("Family Leave", 0);
+        counts.put("Other", 0);
+
+        for (LeaveRequest leaveRequest : leaveRequests) {
+            String leaveType = classifyLeaveType(leaveRequest.getReason());
+            counts.put(leaveType, counts.get(leaveType) + 1);
+        }
+
+        return counts;
+    }
+
+    private String classifyLeaveType(String reason) {
+        if (reason == null) {
+            return "Other";
+        }
+
+        String normalizedReason = reason.toLowerCase(Locale.ROOT);
+
+        if (normalizedReason.contains("om")
+                || normalizedReason.contains("ốm")
+                || normalizedReason.contains("benh")
+                || normalizedReason.contains("bệnh")
+                || normalizedReason.contains("kham")
+                || normalizedReason.contains("khám")
+                || normalizedReason.contains("sick")
+                || normalizedReason.contains("health")) {
+            return "Sick Leave";
+        }
+
+        if (normalizedReason.contains("gia dinh")
+                || normalizedReason.contains("gia đình")
+                || normalizedReason.contains("family")) {
+            return "Family Leave";
+        }
+
+        if (normalizedReason.contains("ca nhan")
+                || normalizedReason.contains("cá nhân")
+                || normalizedReason.contains("viec rieng")
+                || normalizedReason.contains("việc riêng")
+                || normalizedReason.contains("personal")) {
+            return "Personal Leave";
+        }
+
+        return "Other";
+    }
+}

--- a/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
@@ -23,6 +23,8 @@
 	<ul>
 		<li><a href="${pageContext.request.contextPath}/admin/users">Manage
 				Users</a></li>
+		<li><a href="${pageContext.request.contextPath}/admin/leave-statistics">View
+				Leave Statistics</a></li>
 		<%--
 		<li><a href="${pageContext.request.contextPath}/admin/company">Manage
 				Company</a></li>

--- a/XinNghiPhep/src/main/webapp/view/admin/leave-statistics.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/leave-statistics.jsp
@@ -1,0 +1,89 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Leave Statistics</title>
+</head>
+<body>
+	<h2>Leave Statistics</h2>
+
+	<p>
+		<a href="${pageContext.request.contextPath}/admin/dashboard">Back to dashboard</a>
+	</p>
+
+	<form method="get" action="${pageContext.request.contextPath}/admin/leave-statistics" style="margin-bottom: 12px;">
+		<label for="fromDate">From date:</label>
+		<input type="date" id="fromDate" name="fromDate" value="${selectedFromDate}" />
+
+		<label for="toDate">To date:</label>
+		<input type="date" id="toDate" name="toDate" value="${selectedToDate}" />
+
+		<button type="submit">Filter</button>
+		<a href="${pageContext.request.contextPath}/admin/leave-statistics">Reset</a>
+	</form>
+
+	<c:if test="${not empty error}">
+		<p style="color: red;">${error}</p>
+	</c:if>
+
+	<h3>Overview</h3>
+	<p>Total leave requests: <strong>${totalRequests}</strong></p>
+
+	<table border="1" cellpadding="6" cellspacing="0">
+		<tr>
+			<th>Status</th>
+			<th>Total</th>
+		</tr>
+		<c:forEach var="entry" items="${statusCounts}">
+			<tr>
+				<td>${entry.key}</td>
+				<td>${entry.value}</td>
+			</tr>
+		</c:forEach>
+	</table>
+
+	<h3>Leave Type Statistics</h3>
+	<table border="1" cellpadding="6" cellspacing="0">
+		<tr>
+			<th>Leave Type</th>
+			<th>Total</th>
+		</tr>
+		<c:forEach var="entry" items="${leaveTypeCounts}">
+			<tr>
+				<td>${entry.key}</td>
+				<td>${entry.value}</td>
+			</tr>
+		</c:forEach>
+	</table>
+
+	<h3>Filtered Requests</h3>
+	<table border="1" cellpadding="6" cellspacing="0">
+		<tr>
+			<th>ID</th>
+			<th>Employee</th>
+			<th>Start Date</th>
+			<th>End Date</th>
+			<th>Reason</th>
+			<th>Status</th>
+		</tr>
+		<c:forEach var="leaveRequest" items="${filteredLeaveRequests}">
+			<tr>
+				<td>${leaveRequest.id}</td>
+				<td>${leaveRequest.user.fullName}</td>
+				<td>${leaveRequest.startDate}</td>
+				<td>${leaveRequest.endDate}</td>
+				<td>${leaveRequest.reason}</td>
+				<td>${leaveRequest.status}</td>
+			</tr>
+		</c:forEach>
+		<c:if test="${empty filteredLeaveRequests}">
+			<tr>
+				<td colspan="6">No leave requests found.</td>
+			</tr>
+		</c:if>
+	</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implement leave statistics feature for Super Admin.

## Changes
- Add leave statistics page for Super Admin
- Add new route `/admin/leave-statistics`
- Show total leave requests overview
- Show statistics by leave request status (PENDING, APPROVED, REJECTED, CANCELLED)
- Show leave type statistics based on leave request reason
- Add date filter with `fromDate` and `toDate`
- Display filtered leave requests list
- Add navigation link from admin dashboard
- Handle access control for SUPER_ADMIN only
- Handle invalid date range case

## Testing
- Super Admin can open leave statistics page successfully
- Total leave requests display correctly
- Status statistics display correctly from database data
- Leave type statistics display correctly based on reason classification
- Date filter works correctly
- Reset filter works correctly
- Page compiles and loads without server error

## Evidence
- Verified on UI at `/admin/leave-statistics`
- Verified build with `mvn -q -DskipTests compile`

## Jira
ELMS-25
Closes #35