### PR TITLE
[ELMS-29] View Notifications

### DIFF
--- a/XinNghiPhep/src/main/java/nhom13/vn/controller/NotificationController.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/controller/NotificationController.java
@@ -1,0 +1,67 @@
+package nhom13.vn.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nhom13.vn.entity.Notification;
+import nhom13.vn.entity.User;
+import nhom13.vn.service.INotificationService;
+import nhom13.vn.service.impl.NotificationServiceImpl;
+
+@WebServlet("/notifications")
+public class NotificationController extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    private final INotificationService notificationService = NotificationServiceImpl.getInstance();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        User user = (User) req.getSession().getAttribute("account");
+        if (user == null) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        List<Notification> notifications = notificationService.getByViewer(user);
+        req.setAttribute("notifications", notifications);
+        req.getRequestDispatcher("/view/notification/list.jsp").forward(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        User user = (User) req.getSession().getAttribute("account");
+        if (user == null) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        int notificationId;
+        try {
+            notificationId = Integer.parseInt(req.getParameter("id"));
+            if (notificationId <= 0) {
+                throw new NumberFormatException("id must be positive");
+            }
+        } catch (NumberFormatException e) {
+            resp.sendRedirect(req.getContextPath() + "/notifications?msg=invalid");
+            return;
+        }
+
+        boolean updated = notificationService.markAsReadForViewer(notificationId, user);
+        if (updated) {
+            resp.sendRedirect(req.getContextPath() + "/notifications?msg=read");
+            return;
+        }
+
+        resp.sendRedirect(req.getContextPath() + "/notifications?msg=notfound");
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/INotificationDao.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/INotificationDao.java
@@ -1,0 +1,11 @@
+package nhom13.vn.dao;
+
+import java.util.List;
+
+import nhom13.vn.entity.Notification;
+
+public interface INotificationDao {
+    List<Notification> findByReceiver(int receiverId);
+
+    boolean markAsRead(int notificationId, int receiverId);
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/NotificationDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/NotificationDaoImpl.java
@@ -1,0 +1,80 @@
+package nhom13.vn.dao.impl;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.LockModeType;
+import nhom13.vn.config.JPAConfig;
+import nhom13.vn.dao.INotificationDao;
+import nhom13.vn.entity.Notification;
+
+public class NotificationDaoImpl implements INotificationDao {
+
+    private static NotificationDaoImpl instance;
+
+    private NotificationDaoImpl() {
+    }
+
+    public static NotificationDaoImpl getInstance() {
+        if (instance == null) {
+            instance = new NotificationDaoImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public List<Notification> findByReceiver(int receiverId) {
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            return em.createQuery(
+                            "SELECT n FROM Notification n WHERE n.receiver.id = :receiverId ORDER BY n.sentTime DESC, n.id DESC",
+                            Notification.class
+                    )
+                    .setParameter("receiverId", receiverId)
+                    .getResultList();
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public boolean markAsRead(int notificationId, int receiverId) {
+        EntityManager em = JPAConfig.getEntityManager();
+        EntityTransaction trans = em.getTransaction();
+
+        try {
+            trans.begin();
+
+            Notification notification = em.createQuery(
+                            "SELECT n FROM Notification n WHERE n.id = :notificationId AND n.receiver.id = :receiverId",
+                            Notification.class
+                    )
+                    .setParameter("notificationId", notificationId)
+                    .setParameter("receiverId", receiverId)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .getResultStream()
+                    .findFirst()
+                    .orElse(null);
+
+            if (notification == null) {
+                trans.rollback();
+                return false;
+            }
+
+            if (!notification.isRead()) {
+                notification.setRead(true);
+            }
+
+            trans.commit();
+            return true;
+        } catch (Exception e) {
+            if (trans.isActive()) {
+                trans.rollback();
+            }
+            return false;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/entity/Notification.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/entity/Notification.java
@@ -1,6 +1,5 @@
 package nhom13.vn.entity;
 import java.io.Serializable;
-import java.util.List;
 import jakarta.persistence.*;
 @Entity
 @Table(name = "Notifications")
@@ -21,5 +20,43 @@ public class Notification implements Serializable {
     @Temporal(TemporalType.TIMESTAMP)
     private java.util.Date sentTime;
 
-    // Constructors, Getters, Setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public User getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(User receiver) {
+        this.receiver = receiver;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isRead() {
+        return isRead;
+    }
+
+    public void setRead(boolean read) {
+        isRead = read;
+    }
+
+    public java.util.Date getSentTime() {
+        return sentTime;
+    }
+
+    public void setSentTime(java.util.Date sentTime) {
+        this.sentTime = sentTime;
+    }
 }

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/INotificationService.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/INotificationService.java
@@ -1,0 +1,12 @@
+package nhom13.vn.service;
+
+import java.util.List;
+
+import nhom13.vn.entity.Notification;
+import nhom13.vn.entity.User;
+
+public interface INotificationService {
+    List<Notification> getByViewer(User viewer);
+
+    boolean markAsReadForViewer(int notificationId, User viewer);
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/impl/NotificationServiceImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,45 @@
+package nhom13.vn.service.impl;
+
+import java.util.List;
+
+import nhom13.vn.dao.INotificationDao;
+import nhom13.vn.dao.impl.NotificationDaoImpl;
+import nhom13.vn.entity.Notification;
+import nhom13.vn.entity.User;
+import nhom13.vn.service.INotificationService;
+
+public class NotificationServiceImpl implements INotificationService {
+
+    private static NotificationServiceImpl instance;
+
+    private final INotificationDao notificationDao;
+
+    private NotificationServiceImpl() {
+        this.notificationDao = NotificationDaoImpl.getInstance();
+    }
+
+    public static NotificationServiceImpl getInstance() {
+        if (instance == null) {
+            instance = new NotificationServiceImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public List<Notification> getByViewer(User viewer) {
+        if (viewer == null || viewer.getId() <= 0) {
+            return List.of();
+        }
+
+        return notificationDao.findByReceiver(viewer.getId());
+    }
+
+    @Override
+    public boolean markAsReadForViewer(int notificationId, User viewer) {
+        if (viewer == null || viewer.getId() <= 0 || notificationId <= 0) {
+            return false;
+        }
+
+        return notificationDao.markAsRead(notificationId, viewer.getId());
+    }
+}

--- a/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
@@ -23,6 +23,8 @@
 	<ul>
 		<li><a href="${pageContext.request.contextPath}/admin/users">Manage
 				Users</a></li>
+		<li><a href="${pageContext.request.contextPath}/notifications">View
+				Notifications</a></li>
 		<%--
 		<li><a href="${pageContext.request.contextPath}/admin/company">Manage
 				Company</a></li>
@@ -34,6 +36,8 @@
 			href="${pageContext.request.contextPath}/admin/notifications">Manage
 				Notifications</a></li>
 		--%>
+		<li><a href="${pageContext.request.contextPath}/admin/leave-statistics">
+				View Leave Statistics </a></li>
 		<li><a href="${pageContext.request.contextPath}/leave/list">
 				View Leave Requests </a></li>
 	</ul>

--- a/XinNghiPhep/src/main/webapp/view/employee/dashboard.jsp
+++ b/XinNghiPhep/src/main/webapp/view/employee/dashboard.jsp
@@ -17,6 +17,8 @@
 	</hr>
 
 	<ul>
+		<li><a href="${pageContext.request.contextPath}/notifications">
+				View Notifications </a></li>
 		<li><a href="${pageContext.request.contextPath}/leave/create">
 				Request Leave </a></li>
 

--- a/XinNghiPhep/src/main/webapp/view/manager/dashboard.jsp
+++ b/XinNghiPhep/src/main/webapp/view/manager/dashboard.jsp
@@ -14,6 +14,8 @@
 	<ul>
 		<li><a href="${pageContext.request.contextPath}/my-profile">
 				My Profile </a></li>
+		<li><a href="${pageContext.request.contextPath}/notifications">
+				View Notifications </a></li>
 
 		<li><a
 			href="${pageContext.request.contextPath}/manager/zemployeez">

--- a/XinNghiPhep/src/main/webapp/view/notification/list.jsp
+++ b/XinNghiPhep/src/main/webapp/view/notification/list.jsp
@@ -1,0 +1,59 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Notifications</title>
+</head>
+<body>
+	<h2>Notifications</h2>
+
+	<p><a href="${pageContext.request.contextPath}/${sessionScope.account.role == 'SUPER_ADMIN' ? 'admin' : (sessionScope.account.role == 'MANAGER' ? 'manager' : 'employee')}/dashboard">Back to dashboard</a></p>
+
+	<c:if test="${param.msg == 'read'}">
+		<p style="color: green;">Notification marked as read successfully.</p>
+	</c:if>
+	<c:if test="${param.msg == 'invalid'}">
+		<p style="color: red;">Invalid notification id.</p>
+	</c:if>
+	<c:if test="${param.msg == 'notfound'}">
+		<p style="color: red;">Notification not found.</p>
+	</c:if>
+
+	<table border="1" cellpadding="6" cellspacing="0">
+		<tr>
+			<th>ID</th>
+			<th>Content</th>
+			<th>Sent Time</th>
+			<th>Status</th>
+			<th>Action</th>
+		</tr>
+		<c:forEach var="notification" items="${notifications}">
+			<tr>
+				<td>${notification.id}</td>
+				<td>${notification.content}</td>
+				<td>${notification.sentTime}</td>
+				<td>${notification.read ? 'READ' : 'UNREAD'}</td>
+				<td>
+					<c:if test="${not notification.read}">
+						<form method="post" action="${pageContext.request.contextPath}/notifications" style="display:inline;">
+							<input type="hidden" name="id" value="${notification.id}" />
+							<button type="submit">Mark as read</button>
+						</form>
+					</c:if>
+					<c:if test="${notification.read}">
+						<span>-</span>
+					</c:if>
+				</td>
+			</tr>
+		</c:forEach>
+		<c:if test="${empty notifications}">
+			<tr>
+				<td colspan="5">No notifications found.</td>
+			</tr>
+		</c:if>
+	</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implement notification viewing and mark-as-read feature for system users.

## Changes
- Add notifications page for logged-in users
- Add new route `/notifications`
- Show notification list by current receiver
- Display notification content, sent time, and read status
- Add `Mark as read` action for unread notifications
- Update notification status from `UNREAD` to `READ`
- Add DAO layer for querying and updating notifications
- Add service layer for notification retrieval and mark-as-read logic
- Add controller for handling notification list and read actions
- Add navigation link to notifications page from admin, manager, and employee dashboards
- Add getters and setters for `Notification` entity

## Testing
- Logged-in user can open notifications page successfully
- Notification list displays correctly for the current user
- Read and unread notifications are shown with correct status
- User can mark an unread notification as read
- Notification status changes from `UNREAD` to `READ` after action
- Success message displays correctly after marking as read
- Page compiles and loads without server error

## Evidence
- Verified on UI at `/notifications`
- Verified unread notification changed to read after clicking `Mark as read`
- Verified build with `mvn -q -DskipTests compile`

## Jira
ELMS-29
Closes #39