### PR TITLE
ELMS-23 feat: implement auto deduct leave after approval

### DIFF
--- a/XinNghiPhep/bin/pom.xml
+++ b/XinNghiPhep/bin/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nhom13.vn</groupId>
 	<artifactId>XinNghiPhep</artifactId>
@@ -157,6 +157,13 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.17.2</version>
+		</dependency>
+		
+		<!-- PDF generation -->
+		<dependency>
+			<groupId>org.apache.pdfbox</groupId>
+			<artifactId>pdfbox</artifactId>
+			<version>2.0.29</version>
 		</dependency>
 
 		<dependency>

--- a/XinNghiPhep/bin/src/main/resources/META-INF/persistence.xml
+++ b/XinNghiPhep/bin/src/main/resources/META-INF/persistence.xml
@@ -17,7 +17,7 @@
 			<property name="jakarta.persistence.jdbc.user" value="sa" />
 
 			<property name="jakarta.persistence.jdbc.password"
-				value="123456" />
+				value="1" />
 
 			<property name="hibernate.show_sql" value="true" />
 

--- a/XinNghiPhep/bin/src/main/webapp/view/leave/list.jsp
+++ b/XinNghiPhep/bin/src/main/webapp/view/leave/list.jsp
@@ -10,6 +10,11 @@
 </head>
 <body>
 	<h2>${empty pageTitle ? 'Leave Requests List' : pageTitle}</h2>
+	<c:if test="${sessionScope.account.role == 'MANAGER' || sessionScope.account.role == 'SUPER_ADMIN'}">
+		<p>
+			<a href="${pageContext.request.contextPath}/leave/report?status=${selectedStatus}">Download PDF</a>
+		</p>
+	</c:if>
 	<c:if test="${param.msg == 'approved'}">
 		<p style="color: green;">Leave request approved successfully.</p>
 	</c:if>

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
@@ -20,6 +20,8 @@ import nhom13.vn.entity.LeaveRequest;
 import nhom13.vn.entity.User;
 
 public class LeaveRequestDaoImpl implements ILeaveRequestDao {
+	
+	private static final int DEFAULT_LEAVE_DAYS = 12;//thêm mới
 
     private static LeaveRequestDaoImpl instance;
 
@@ -361,9 +363,16 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
 
                 leaveBalance = new LeaveBalance();
                 leaveBalance.setUser(leaveRequest.getUser());
-                leaveBalance.setTotalDays(12);
+                //leaveBalance.setTotalDays(12);
+                
+                leaveBalance.setTotalDays(DEFAULT_LEAVE_DAYS);//thêm mới
+                
                 leaveBalance.setUsedDays(0);
-                leaveBalance.setRemainingDays(12);
+                //leaveBalance.setRemainingDays(12);
+                
+                leaveBalance.setRemainingDays(DEFAULT_LEAVE_DAYS);// thêm mới
+
+                
                 leaveBalance.setLastResetYear(LocalDate.now().getYear());
                 em.persist(leaveBalance);
             }
@@ -430,9 +439,17 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
 
                 leaveBalance = new LeaveBalance();
                 leaveBalance.setUser(leaveRequest.getUser());
-                leaveBalance.setTotalDays(12);
+                //leaveBalance.setTotalDays(12);
+                
+                leaveBalance.setTotalDays(DEFAULT_LEAVE_DAYS);// thêm mới
+
+                
                 leaveBalance.setUsedDays(0);
-                leaveBalance.setRemainingDays(12);
+                //leaveBalance.setRemainingDays(12);
+                
+                leaveBalance.setRemainingDays(DEFAULT_LEAVE_DAYS);// thêm mới
+
+                
                 leaveBalance.setLastResetYear(LocalDate.now().getYear());
                 em.persist(leaveBalance);
             }
@@ -447,6 +464,9 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
             upsertApproval(em, leaveRequest, reviewer, "APPROVED", note);
             leaveBalance.setUsedDays(leaveBalance.getUsedDays() + requestedDays);
             leaveBalance.setRemainingDays(leaveBalance.getRemainingDays() - requestedDays);
+            
+            leaveBalance.setTotalDays(leaveBalance.getUsedDays() + leaveBalance.getRemainingDays());// thêm mới
+
 
             trans.commit();
             return true;
@@ -546,6 +566,10 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
     }
 
     private int calculateRequestedDays(LeaveRequest leaveRequest) {
+    	
+    	if (leaveRequest.getStartDate() == null || leaveRequest.getEndDate() == null) {
+            return 0;
+        }// thêm mới
         LocalDate startDate = LocalDate.ofInstant(
                 java.time.Instant.ofEpochMilli(leaveRequest.getStartDate().getTime()),
                 ZoneId.systemDefault()


### PR DESCRIPTION
[ELMS-23] Auto Deduct Leave After Approval

## Summary
Automatically deduct leave balance after approval so that leave records remain accurate.

## Changes
- Implement auto deduction of leave balance when leave request is approved
- Ensure deduction only happens when status = APPROVED
- Do not deduct leave balance when request is rejected
- Prevent double deduction for the same request
- Update leave balance accurately in database
- Update DAO, Service, Controller layers
- Handle validation and edge cases during approval process

## Testing
- When request is approved → leave balance is deducted correctly
- When request is rejected → no deduction occurs
- Approving the same request multiple times → no double deduction
- Leave balance updates correctly in database
- Data consistency is maintained after operations

## Evidence
- Verified leave balance update in database (Users / LeaveRequests table)

## Jira
ELMS-23
Closes #33 


[ELMS-23]: https://levanphong511.atlassian.net/browse/ELMS-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ