### PR TITLE
[ELMS-31] Manage Leave Types (CRUD)

### DIFF
--- a/XinNghiPhep/.project
+++ b/XinNghiPhep/.project
@@ -34,4 +34,15 @@
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1775360466857</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/XinNghiPhep/src/main/java/nhom13/vn/controller/AdminLeaveTypeController.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/controller/AdminLeaveTypeController.java
@@ -1,0 +1,158 @@
+package nhom13.vn.controller;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nhom13.vn.entity.LeaveType;
+import nhom13.vn.entity.User;
+import nhom13.vn.service.ILeaveTypeService;
+import nhom13.vn.service.impl.LeaveTypeServiceImpl;
+
+@WebServlet({
+        "/admin/leave-types",
+        "/admin/leave-types/add",
+        "/admin/leave-types/insert",
+        "/admin/leave-types/edit",
+        "/admin/leave-types/update",
+        "/admin/leave-types/delete"
+})
+public class AdminLeaveTypeController extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ILeaveTypeService leaveTypeService = LeaveTypeServiceImpl.getInstance();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        User user = (User) req.getSession().getAttribute("account");
+        if (user == null || !"SUPER_ADMIN".equals(user.getRole())) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        leaveTypeService.ensureSystemDefaults();
+
+        String uri = req.getRequestURI();
+
+        if (uri.contains("/add")) {
+            req.getRequestDispatcher("/view/admin/leave-type-form.jsp").forward(req, resp);
+            return;
+        }
+
+        if (uri.contains("/edit")) {
+            int id = parsePositiveInt(req.getParameter("id"), -1);
+            if (id <= 0) {
+                resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                return;
+            }
+            LeaveType leaveType = leaveTypeService.findById(id);
+            if (leaveType == null) {
+                resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                return;
+            }
+            req.setAttribute("leaveType", leaveType);
+            req.getRequestDispatcher("/view/admin/leave-type-form.jsp").forward(req, resp);
+            return;
+        }
+
+        if (uri.contains("/delete")) {
+            int id = parsePositiveInt(req.getParameter("id"), -1);
+            boolean deleted = id > 0 && leaveTypeService.deleteById(id);
+            if (!deleted) {
+                req.getSession().setAttribute("message",
+                        "Không thể xóa: loại nghỉ còn đang active, hoặc đang được dùng trong đơn nghỉ, hoặc không tồn tại.");
+            } else {
+                req.getSession().setAttribute("message", "Đã xóa loại nghỉ.");
+            }
+            resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+            return;
+        }
+
+        req.setAttribute("list", leaveTypeService.findAll());
+        req.getRequestDispatcher("/view/admin/leave-types.jsp").forward(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        User user = (User) req.getSession().getAttribute("account");
+        if (user == null || !"SUPER_ADMIN".equals(user.getRole())) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        req.setCharacterEncoding("UTF-8");
+        leaveTypeService.ensureSystemDefaults();
+
+        String uri = req.getRequestURI();
+
+        try {
+            if (uri.contains("/insert")) {
+                LeaveType lt = new LeaveType();
+                lt.setCode(req.getParameter("code"));
+                lt.setName(req.getParameter("name"));
+                lt.setConsumesBalance(req.getParameter("consumesBalance") != null);
+                lt.setDefaultDaysPerYear(parseNonNegativeInt(req.getParameter("defaultDaysPerYear"), 0));
+                lt.setActive(req.getParameter("active") != null);
+
+                leaveTypeService.create(lt);
+                req.getSession().setAttribute("message", "Đã thêm loại nghỉ.");
+                resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                return;
+            }
+
+            if (uri.contains("/update")) {
+                int id = parsePositiveInt(req.getParameter("id"), -1);
+                if (id <= 0) {
+                    resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                    return;
+                }
+                LeaveType lt = leaveTypeService.findById(id);
+                if (lt == null) {
+                    resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                    return;
+                }
+                lt.setName(req.getParameter("name"));
+                lt.setConsumesBalance(req.getParameter("consumesBalance") != null);
+                lt.setDefaultDaysPerYear(parseNonNegativeInt(req.getParameter("defaultDaysPerYear"), 0));
+                lt.setActive(req.getParameter("active") != null);
+
+                leaveTypeService.update(lt);
+                req.getSession().setAttribute("message", "Đã cập nhật loại nghỉ.");
+                resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+                return;
+            }
+        } catch (Exception e) {
+            req.getSession().setAttribute("message", "Lỗi: " + e.getMessage());
+        }
+
+        resp.sendRedirect(req.getContextPath() + "/admin/leave-types");
+    }
+
+    private static int parsePositiveInt(String raw, int defaultValue) {
+        if (raw == null || raw.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            int v = Integer.parseInt(raw.trim());
+            return v > 0 ? v : defaultValue;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static int parseNonNegativeInt(String raw, int defaultValue) {
+        if (raw == null || raw.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            int v = Integer.parseInt(raw.trim());
+            return Math.max(0, v);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/controller/LeaveRequestController.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/controller/LeaveRequestController.java
@@ -5,13 +5,16 @@ import jakarta.servlet.http.*;
 
 import nhom13.vn.entity.LeaveBalance;
 import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.LeaveType;
 import nhom13.vn.entity.User;
 import nhom13.vn.factory.LeaveRequestFactory;
 import nhom13.vn.service.ILeaveBalanceService;
 import nhom13.vn.service.ILeaveRequestService;
+import nhom13.vn.service.ILeaveTypeService;
 import nhom13.vn.service.INotificationService;
 import nhom13.vn.service.impl.LeaveBalanceServiceImpl;
 import nhom13.vn.service.impl.LeaveRequestServiceImpl;
+import nhom13.vn.service.impl.LeaveTypeServiceImpl;
 import nhom13.vn.service.impl.NotificationServiceImpl;
 
 import java.io.IOException;
@@ -25,6 +28,7 @@ public class LeaveRequestController extends HttpServlet {
 
     ILeaveRequestService service = new LeaveRequestServiceImpl();
     ILeaveBalanceService leaveBalanceService = LeaveBalanceServiceImpl.getInstance();
+    ILeaveTypeService leaveTypeService = LeaveTypeServiceImpl.getInstance();
     INotificationService notificationService = NotificationServiceImpl.getInstance();
 
     @Override
@@ -44,8 +48,11 @@ public class LeaveRequestController extends HttpServlet {
             return;
         }
 
+        leaveTypeService.ensureSystemDefaults();
+
         LeaveBalance leaveBalance = leaveBalanceService.ensureDefaultForUser(user);
         req.setAttribute("leaveBalance", leaveBalance);
+        req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
 
         req.getRequestDispatcher("/view/leave/create.jsp")
                 .forward(req, resp);
@@ -60,18 +67,11 @@ public class LeaveRequestController extends HttpServlet {
         String start = req.getParameter("startDate");
         String end = req.getParameter("endDate");
         String reason = req.getParameter("reason");
+        String leaveTypeIdRaw = req.getParameter("leaveTypeId");
 
-        // validation
-        if (start == null || end == null || reason == null ||
-            start.isEmpty() || end.isEmpty() || reason.isEmpty()) {
-
-            req.setAttribute("alert", "Vui lòng nhập đầy đủ!");
-            req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
-            return;
-        }
+        leaveTypeService.ensureSystemDefaults();
 
         User user = (User) req.getSession().getAttribute("account");
-
         if (user == null) {
             resp.sendRedirect(req.getContextPath() + "/login");
             return;
@@ -83,8 +83,36 @@ public class LeaveRequestController extends HttpServlet {
             return;
         }
 
-        LeaveBalance leaveBalance = leaveBalanceService.ensureDefaultForUser(user);
-        req.setAttribute("leaveBalance", leaveBalance);
+        LeaveBalance leaveBalanceForForm = leaveBalanceService.ensureDefaultForUser(user);
+        req.setAttribute("leaveBalance", leaveBalanceForForm);
+        req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
+
+        // validation
+        if (start == null || end == null || reason == null ||
+            start.isEmpty() || end.isEmpty() || reason.isEmpty()) {
+
+            req.setAttribute("alert", "Vui lòng nhập đầy đủ!");
+            req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
+            return;
+        }
+
+        int leaveTypeId;
+        try {
+            leaveTypeId = Integer.parseInt(leaveTypeIdRaw != null ? leaveTypeIdRaw.trim() : "");
+        } catch (NumberFormatException e) {
+            req.setAttribute("alert", "Vui lòng chọn loại nghỉ.");
+            req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
+            return;
+        }
+
+        LeaveType leaveType = leaveTypeService.findById(leaveTypeId);
+        if (leaveType == null || !leaveType.isActive()) {
+            req.setAttribute("alert", "Loại nghỉ không hợp lệ.");
+            req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
+            return;
+        }
+
+        LeaveBalance leaveBalance = leaveBalanceForForm;
 
         if (leaveBalance == null) {
             req.setAttribute("alert", "Tai khoan nay khong ap dung nghi phep.");
@@ -97,6 +125,8 @@ public class LeaveRequestController extends HttpServlet {
             LocalDate endDate = LocalDate.parse(end);
 
             if (endDate.isBefore(startDate)) {
+                req.setAttribute("leaveBalance", leaveBalance);
+                req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
                 req.setAttribute("alert", "Ngay ket thuc phai >= ngay bat dau.");
                 req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
                 return;
@@ -104,19 +134,23 @@ public class LeaveRequestController extends HttpServlet {
 
             long requestedDays = ChronoUnit.DAYS.between(startDate, endDate) + 1;
             if (requestedDays <= 0) {
+                req.setAttribute("leaveBalance", leaveBalance);
+                req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
                 req.setAttribute("alert", "So ngay nghi khong hop le.");
                 req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
                 return;
             }
 
-            if (requestedDays > leaveBalance.getRemainingDays()) {
+            boolean consumesBalance = leaveType.isConsumesBalance();
+            if (consumesBalance && requestedDays > leaveBalance.getRemainingDays()) {
+                req.setAttribute("leaveBalance", leaveBalance);
+                req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
                 req.setAttribute("alert", "So ngay nghi vuot qua so ngay con lai.");
                 req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
                 return;
             }
 
-            // 🔥 DÙNG FACTORY
-            LeaveRequest lr = LeaveRequestFactory.create(user, start, end, reason);
+            LeaveRequest lr = LeaveRequestFactory.create(user, start, end, reason, leaveType);
 
             service.create(lr);
             notificationService.notifyManagersAboutSubmittedLeaveRequest(user, lr);
@@ -133,6 +167,8 @@ public class LeaveRequestController extends HttpServlet {
             }
 
         } catch (Exception e) {
+            req.setAttribute("leaveBalance", leaveBalanceService.ensureDefaultForUser(user));
+            req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
             req.setAttribute("alert", "Lỗi dữ liệu!");
             req.getRequestDispatcher("/view/leave/create.jsp").forward(req, resp);
         }

--- a/XinNghiPhep/src/main/java/nhom13/vn/controller/LeaveRequestEditController.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/controller/LeaveRequestEditController.java
@@ -11,11 +11,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nhom13.vn.entity.LeaveBalance;
 import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.LeaveType;
 import nhom13.vn.entity.User;
 import nhom13.vn.service.ILeaveBalanceService;
 import nhom13.vn.service.ILeaveRequestService;
+import nhom13.vn.service.ILeaveTypeService;
 import nhom13.vn.service.impl.LeaveBalanceServiceImpl;
 import nhom13.vn.service.impl.LeaveRequestServiceImpl;
+import nhom13.vn.service.impl.LeaveTypeServiceImpl;
 
 @WebServlet({ "/leave/edit", "/leave/update" })
 public class LeaveRequestEditController extends HttpServlet {
@@ -24,6 +27,7 @@ public class LeaveRequestEditController extends HttpServlet {
 
     private final ILeaveRequestService leaveRequestService = LeaveRequestServiceImpl.getInstance();
     private final ILeaveBalanceService leaveBalanceService = LeaveBalanceServiceImpl.getInstance();
+    private final ILeaveTypeService leaveTypeService = LeaveTypeServiceImpl.getInstance();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -58,9 +62,12 @@ public class LeaveRequestEditController extends HttpServlet {
             return;
         }
 
+        leaveTypeService.ensureSystemDefaults();
+
         LeaveBalance leaveBalance = leaveBalanceService.ensureDefaultForUser(user);
         req.setAttribute("leaveRequest", leaveRequest);
         req.setAttribute("leaveBalance", leaveBalance);
+        req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
         req.getRequestDispatcher("/view/leave/edit.jsp").forward(req, resp);
     }
 
@@ -102,10 +109,14 @@ public class LeaveRequestEditController extends HttpServlet {
         String start = req.getParameter("startDate");
         String end = req.getParameter("endDate");
         String reason = req.getParameter("reason");
+        Integer leaveTypeId = parseOptionalLeaveTypeId(req.getParameter("leaveTypeId"));
+
+        leaveTypeService.ensureSystemDefaults();
 
         LeaveBalance leaveBalance = leaveBalanceService.ensureDefaultForUser(user);
         req.setAttribute("leaveRequest", leaveRequest);
         req.setAttribute("leaveBalance", leaveBalance);
+        req.setAttribute("leaveTypes", leaveTypeService.findAllActive());
 
         if (start == null || end == null || reason == null
                 || start.isEmpty() || end.isEmpty() || reason.isEmpty()) {
@@ -137,13 +148,22 @@ public class LeaveRequestEditController extends HttpServlet {
                 return;
             }
 
-            if (requestedDays > leaveBalance.getRemainingDays()) {
+            LeaveType effectiveType = resolveEffectiveLeaveType(leaveRequest, leaveTypeId);
+            if (leaveTypeId != null && (effectiveType == null || !effectiveType.isActive())) {
+                req.setAttribute("alert", "Loại nghỉ không hợp lệ.");
+                req.getRequestDispatcher("/view/leave/edit.jsp").forward(req, resp);
+                return;
+            }
+
+            boolean consumesBalance = effectiveType == null || effectiveType.isConsumesBalance();
+            if (consumesBalance && requestedDays > leaveBalance.getRemainingDays()) {
                 req.setAttribute("alert", "So ngay nghi vuot qua so ngay con lai.");
                 req.getRequestDispatcher("/view/leave/edit.jsp").forward(req, resp);
                 return;
             }
 
-            boolean ok = leaveRequestService.updatePendingForEmployee(leaveId, user, startDate, endDate, reason);
+            boolean ok = leaveRequestService.updatePendingForEmployee(leaveId, user, startDate, endDate, reason,
+                    leaveTypeId);
             if (ok) {
                 req.getSession().setAttribute("message", "Cập nhật đơn nghỉ thành công!");
                 resp.sendRedirect(req.getContextPath() + "/leave/detail?id=" + leaveId);
@@ -156,6 +176,25 @@ public class LeaveRequestEditController extends HttpServlet {
             req.setAttribute("alert", "Lỗi dữ liệu!");
             req.getRequestDispatcher("/view/leave/edit.jsp").forward(req, resp);
         }
+    }
+
+    private static Integer parseOptionalLeaveTypeId(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            int id = Integer.parseInt(raw.trim());
+            return id > 0 ? id : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private LeaveType resolveEffectiveLeaveType(LeaveRequest leaveRequest, Integer leaveTypeId) {
+        if (leaveTypeId != null) {
+            return leaveTypeService.findById(leaveTypeId);
+        }
+        return leaveRequest.getLeaveType();
     }
 
     private static int parseLeaveId(String idRaw) {

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveBalanceDao.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveBalanceDao.java
@@ -1,12 +1,21 @@
 package nhom13.vn.dao;
 
+import java.util.List;
+
 import nhom13.vn.entity.LeaveBalance;
 
 public interface ILeaveBalanceDao {
     LeaveBalance findByUserId(int userId);
 
+    List<LeaveBalance> findAll();
+
     void insert(LeaveBalance leaveBalance);
 
     void update(LeaveBalance leaveBalance);
+
+    /**
+     * Adjusts every balance: {@code total += delta} (never below used), then {@code remaining = total - used}.
+     */
+    void applyAnnualPolicyDayDelta(int delta);
 }
 

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveRequestDao.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveRequestDao.java
@@ -57,5 +57,6 @@ public interface ILeaveRequestDao {
      * Updates start/end/reason only when the request belongs to {@code userId} and status is PENDING.
      * Re-validates remaining leave balance against the new date range inside the transaction.
      */
-    boolean updatePendingForUser(int leaveId, int userId, Date startDate, Date endDate, String reason);
+    boolean updatePendingForUser(int leaveId, int userId, Date startDate, Date endDate, String reason,
+            Integer leaveTypeId);
 }

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveTypeDao.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/ILeaveTypeDao.java
@@ -1,0 +1,24 @@
+package nhom13.vn.dao;
+
+import java.util.List;
+
+import nhom13.vn.entity.LeaveType;
+
+public interface ILeaveTypeDao {
+
+    List<LeaveType> findAllOrderByCode();
+
+    List<LeaveType> findAllActiveOrderByCode();
+
+    LeaveType findById(int id);
+
+    LeaveType findByCode(String code);
+
+    long countUsage(int leaveTypeId);
+
+    void insert(LeaveType leaveType);
+
+    void update(LeaveType leaveType);
+
+    void delete(LeaveType leaveType);
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveBalanceDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveBalanceDaoImpl.java
@@ -1,6 +1,7 @@
 package nhom13.vn.dao.impl;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
@@ -20,6 +21,16 @@ public class LeaveBalanceDaoImpl implements ILeaveBalanceDao {
 					.getSingleResult();
 		} catch (NoResultException e) {
 			return null;
+		} finally {
+			em.close();
+		}
+	}
+
+	@Override
+	public List<LeaveBalance> findAll() {
+		EntityManager em = JPAConfig.getEntityManager();
+		try {
+			return em.createQuery("SELECT lb FROM LeaveBalance lb", LeaveBalance.class).getResultList();
 		} finally {
 			em.close();
 		}
@@ -54,6 +65,36 @@ public class LeaveBalanceDaoImpl implements ILeaveBalanceDao {
 		try {
 			trans.begin();
 			em.merge(leaveBalance);
+			trans.commit();
+		} catch (Exception e) {
+			if (trans.isActive()) {
+				trans.rollback();
+			}
+			throw e;
+		} finally {
+			em.close();
+		}
+	}
+
+	@Override
+	public void applyAnnualPolicyDayDelta(int delta) {
+		if (delta == 0) {
+			return;
+		}
+		EntityManager em = JPAConfig.getEntityManager();
+		EntityTransaction trans = em.getTransaction();
+		try {
+			trans.begin();
+			List<LeaveBalance> all = em.createQuery("SELECT lb FROM LeaveBalance lb", LeaveBalance.class)
+					.getResultList();
+			for (LeaveBalance lb : all) {
+				int newTotal = lb.getTotalDays() + delta;
+				if (newTotal < lb.getUsedDays()) {
+					newTotal = lb.getUsedDays();
+				}
+				lb.setTotalDays(newTotal);
+				lb.setRemainingDays(newTotal - lb.getUsedDays());
+			}
 			trans.commit();
 		} catch (Exception e) {
 			if (trans.isActive()) {

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveRequestDaoImpl.java
@@ -17,11 +17,13 @@ import nhom13.vn.dao.ILeaveRequestDao;
 import nhom13.vn.entity.LeaveApproval;
 import nhom13.vn.entity.LeaveBalance;
 import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.LeaveType;
 import nhom13.vn.entity.User;
+import nhom13.vn.utils.LeaveRequestBalanceUtil;
 
 public class LeaveRequestDaoImpl implements ILeaveRequestDao {
-	
-	private static final int DEFAULT_LEAVE_DAYS = 12;//thêm mới
+
+    private static final int FALLBACK_ANNUAL_DAYS = 12;
 
     private static LeaveRequestDaoImpl instance;
 
@@ -310,7 +312,7 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
 
     @Override
     public boolean updatePendingForUser(int leaveId, int userId, java.sql.Date startDate, java.sql.Date endDate,
-            String reason) {
+            String reason, Integer leaveTypeId) {
         EntityManager em = JPAConfig.getEntityManager();
         EntityTransaction trans = em.getTransaction();
 
@@ -333,6 +335,15 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
                 return false;
             }
 
+            if (leaveTypeId != null) {
+                LeaveType newType = em.find(LeaveType.class, leaveTypeId);
+                if (newType == null || !newType.isActive()) {
+                    trans.rollback();
+                    return false;
+                }
+                leaveRequest.setLeaveType(newType);
+            }
+
             LocalDate startLocal = startDate.toLocalDate();
             LocalDate endLocal = endDate.toLocalDate();
             if (endLocal.isBefore(startLocal)) {
@@ -345,41 +356,38 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
                 return false;
             }
 
-            LeaveBalance leaveBalance;
-            try {
-                leaveBalance = em.createQuery(
-                                "SELECT lb FROM LeaveBalance lb WHERE lb.user.id = :userId",
-                                LeaveBalance.class
-                        )
-                        .setParameter("userId", userId)
-                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
-                        .getSingleResult();
-            } catch (NoResultException e) {
-                String role = leaveRequest.getUser().getRole();
-                if (!"EMPLOYEE".equals(role) && !"MANAGER".equals(role)) {
+            if (LeaveRequestBalanceUtil.consumesAnnualPool(leaveRequest)) {
+                LeaveBalance leaveBalance;
+                try {
+                    leaveBalance = em.createQuery(
+                                    "SELECT lb FROM LeaveBalance lb WHERE lb.user.id = :userId",
+                                    LeaveBalance.class
+                            )
+                            .setParameter("userId", userId)
+                            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                            .getSingleResult();
+                } catch (NoResultException e) {
+                    String role = leaveRequest.getUser().getRole();
+                    if (!"EMPLOYEE".equals(role) && !"MANAGER".equals(role)) {
+                        trans.rollback();
+                        return false;
+                    }
+
+                    int defaultDays = resolveAnnualDefaultDays(em);
+
+                    leaveBalance = new LeaveBalance();
+                    leaveBalance.setUser(leaveRequest.getUser());
+                    leaveBalance.setTotalDays(defaultDays);
+                    leaveBalance.setUsedDays(0);
+                    leaveBalance.setRemainingDays(defaultDays);
+                    leaveBalance.setLastResetYear(LocalDate.now().getYear());
+                    em.persist(leaveBalance);
+                }
+
+                if (leaveBalance.getRemainingDays() < requestedDays) {
                     trans.rollback();
                     return false;
                 }
-
-                leaveBalance = new LeaveBalance();
-                leaveBalance.setUser(leaveRequest.getUser());
-                //leaveBalance.setTotalDays(12);
-                
-                leaveBalance.setTotalDays(DEFAULT_LEAVE_DAYS);//thêm mới
-                
-                leaveBalance.setUsedDays(0);
-                //leaveBalance.setRemainingDays(12);
-                
-                leaveBalance.setRemainingDays(DEFAULT_LEAVE_DAYS);// thêm mới
-
-                
-                leaveBalance.setLastResetYear(LocalDate.now().getYear());
-                em.persist(leaveBalance);
-            }
-
-            if (leaveBalance.getRemainingDays() < requestedDays) {
-                trans.rollback();
-                return false;
             }
 
             leaveRequest.setStartDate(startDate);
@@ -421,6 +429,19 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
                 return false;
             }
 
+            int requestedDays = calculateRequestedDays(leaveRequest);
+            if (requestedDays <= 0) {
+                trans.rollback();
+                return false;
+            }
+
+            if (!LeaveRequestBalanceUtil.consumesAnnualPool(leaveRequest)) {
+                leaveRequest.setStatus("APPROVED");
+                upsertApproval(em, leaveRequest, reviewer, "APPROVED", note);
+                trans.commit();
+                return true;
+            }
+
             LeaveBalance leaveBalance;
             try {
                 leaveBalance = em.createQuery(
@@ -437,25 +458,18 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
                     return false;
                 }
 
+                int defaultDays = resolveAnnualDefaultDays(em);
+
                 leaveBalance = new LeaveBalance();
                 leaveBalance.setUser(leaveRequest.getUser());
-                //leaveBalance.setTotalDays(12);
-                
-                leaveBalance.setTotalDays(DEFAULT_LEAVE_DAYS);// thêm mới
-
-                
+                leaveBalance.setTotalDays(defaultDays);
                 leaveBalance.setUsedDays(0);
-                //leaveBalance.setRemainingDays(12);
-                
-                leaveBalance.setRemainingDays(DEFAULT_LEAVE_DAYS);// thêm mới
-
-                
+                leaveBalance.setRemainingDays(defaultDays);
                 leaveBalance.setLastResetYear(LocalDate.now().getYear());
                 em.persist(leaveBalance);
             }
 
-            int requestedDays = calculateRequestedDays(leaveRequest);
-            if (requestedDays <= 0 || leaveBalance.getRemainingDays() < requestedDays) {
+            if (leaveBalance.getRemainingDays() < requestedDays) {
                 trans.rollback();
                 return false;
             }
@@ -464,9 +478,7 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
             upsertApproval(em, leaveRequest, reviewer, "APPROVED", note);
             leaveBalance.setUsedDays(leaveBalance.getUsedDays() + requestedDays);
             leaveBalance.setRemainingDays(leaveBalance.getRemainingDays() - requestedDays);
-            
-            leaveBalance.setTotalDays(leaveBalance.getUsedDays() + leaveBalance.getRemainingDays());// thêm mới
-
+            leaveBalance.setTotalDays(leaveBalance.getUsedDays() + leaveBalance.getRemainingDays());
 
             trans.commit();
             return true;
@@ -584,6 +596,23 @@ public class LeaveRequestDaoImpl implements ILeaveRequestDao {
         }
 
         return (int) (ChronoUnit.DAYS.between(startDate, endDate) + 1);
+    }
+
+    private int resolveAnnualDefaultDays(EntityManager em) {
+        try {
+            LeaveType annual = em.createQuery(
+                            "SELECT t FROM LeaveType t WHERE t.code = :code",
+                            LeaveType.class
+                    )
+                    .setParameter("code", LeaveType.CODE_ANNUAL)
+                    .getSingleResult();
+            if (annual.getDefaultDaysPerYear() > 0) {
+                return annual.getDefaultDaysPerYear();
+            }
+        } catch (NoResultException ignored) {
+            // fall through
+        }
+        return FALLBACK_ANNUAL_DAYS;
     }
 
     public static LeaveRequestDaoImpl getInstance() {

--- a/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveTypeDaoImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/dao/impl/LeaveTypeDaoImpl.java
@@ -1,0 +1,137 @@
+package nhom13.vn.dao.impl;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.NoResultException;
+import nhom13.vn.config.JPAConfig;
+import nhom13.vn.dao.ILeaveTypeDao;
+import nhom13.vn.entity.LeaveType;
+
+public class LeaveTypeDaoImpl implements ILeaveTypeDao {
+
+    @Override
+    public List<LeaveType> findAllOrderByCode() {
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            return em.createQuery("SELECT t FROM LeaveType t ORDER BY t.code", LeaveType.class).getResultList();
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public List<LeaveType> findAllActiveOrderByCode() {
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            return em.createQuery(
+                            "SELECT t FROM LeaveType t WHERE t.active = true ORDER BY t.code",
+                            LeaveType.class
+                    )
+                    .getResultList();
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public LeaveType findById(int id) {
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            return em.find(LeaveType.class, id);
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public LeaveType findByCode(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            return em.createQuery("SELECT t FROM LeaveType t WHERE t.code = :code", LeaveType.class)
+                    .setParameter("code", code.trim().toUpperCase())
+                    .getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public long countUsage(int leaveTypeId) {
+        EntityManager em = JPAConfig.getEntityManager();
+        try {
+            Long count = em.createQuery(
+                            "SELECT COUNT(lr) FROM LeaveRequest lr WHERE lr.leaveType.id = :tid",
+                            Long.class
+                    )
+                    .setParameter("tid", leaveTypeId)
+                    .getSingleResult();
+            return count != null ? count : 0L;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void insert(LeaveType leaveType) {
+        EntityManager em = JPAConfig.getEntityManager();
+        EntityTransaction trans = em.getTransaction();
+        try {
+            trans.begin();
+            em.persist(leaveType);
+            trans.commit();
+        } catch (Exception e) {
+            if (trans.isActive()) {
+                trans.rollback();
+            }
+            throw e;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void update(LeaveType leaveType) {
+        EntityManager em = JPAConfig.getEntityManager();
+        EntityTransaction trans = em.getTransaction();
+        try {
+            trans.begin();
+            em.merge(leaveType);
+            trans.commit();
+        } catch (Exception e) {
+            if (trans.isActive()) {
+                trans.rollback();
+            }
+            throw e;
+        } finally {
+            em.close();
+        }
+    }
+
+    @Override
+    public void delete(LeaveType leaveType) {
+        EntityManager em = JPAConfig.getEntityManager();
+        EntityTransaction trans = em.getTransaction();
+        try {
+            trans.begin();
+            LeaveType managed = em.find(LeaveType.class, leaveType.getId());
+            if (managed != null) {
+                em.remove(managed);
+            }
+            trans.commit();
+        } catch (Exception e) {
+            if (trans.isActive()) {
+                trans.rollback();
+            }
+            throw e;
+        } finally {
+            em.close();
+        }
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/entity/LeaveRequest.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/entity/LeaveRequest.java
@@ -16,6 +16,10 @@ public class LeaveRequest implements Serializable {
     @JoinColumn(name = "userId")
     private User user;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "leaveTypeId")
+    private LeaveType leaveType;
+
     @Temporal(TemporalType.DATE) // Lưu trữ ngày [5, 12]
     private java.util.Date startDate;
 
@@ -36,6 +40,9 @@ public class LeaveRequest implements Serializable {
 
     public User getUser() { return user; }
     public void setUser(User user) { this.user = user; }
+
+    public LeaveType getLeaveType() { return leaveType; }
+    public void setLeaveType(LeaveType leaveType) { this.leaveType = leaveType; }
 
     public Date getStartDate() { return (Date) startDate; }
     public void setStartDate(Date startDate) { this.startDate = startDate; }

--- a/XinNghiPhep/src/main/java/nhom13/vn/entity/LeaveType.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/entity/LeaveType.java
@@ -1,0 +1,91 @@
+package nhom13.vn.entity;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "LeaveTypes", uniqueConstraints = @UniqueConstraint(columnNames = "code"))
+public class LeaveType implements Serializable {
+
+    public static final String CODE_ANNUAL = "ANNUAL";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    /**
+     * When true, pending validation and approval deduct from the user's annual leave pool ({@link LeaveBalance}).
+     */
+    @Column(nullable = false)
+    private boolean consumesBalance;
+
+    /**
+     * For {@link #CODE_ANNUAL}, defines default days per year for new balances and drives policy-wide adjustments.
+     */
+    @Column(nullable = false)
+    private int defaultDaysPerYear;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isConsumesBalance() {
+        return consumesBalance;
+    }
+
+    public void setConsumesBalance(boolean consumesBalance) {
+        this.consumesBalance = consumesBalance;
+    }
+
+    public int getDefaultDaysPerYear() {
+        return defaultDaysPerYear;
+    }
+
+    public void setDefaultDaysPerYear(int defaultDaysPerYear) {
+        this.defaultDaysPerYear = defaultDaysPerYear;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/factory/LeaveRequestFactory.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/factory/LeaveRequestFactory.java
@@ -1,17 +1,19 @@
 package nhom13.vn.factory;
 
 import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.LeaveType;
 import nhom13.vn.entity.User;
 
 import java.sql.Date;
 
 public class LeaveRequestFactory {
 
-    public static LeaveRequest create(User user, String start, String end, String reason) {
+    public static LeaveRequest create(User user, String start, String end, String reason, LeaveType leaveType) {
 
         LeaveRequest lr = new LeaveRequest();
 
         lr.setUser(user);
+        lr.setLeaveType(leaveType);
         lr.setStartDate(Date.valueOf(start));
         lr.setEndDate(Date.valueOf(end));
         lr.setReason(reason);

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveBalanceService.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveBalanceService.java
@@ -4,10 +4,12 @@ import nhom13.vn.entity.LeaveBalance;
 import nhom13.vn.entity.User;
 
 public interface ILeaveBalanceService {
-	LeaveBalance findByUserId(int userId);
+    LeaveBalance findByUserId(int userId);
 
-	LeaveBalance ensureDefaultForUser(User user);
+    LeaveBalance ensureDefaultForUser(User user);
 
-	void updateRemainingDays(int userId, int remainingDays);
+    void updateRemainingDays(int userId, int remainingDays);
+
+    void applyAnnualPolicyDayDelta(int delta);
 }
 

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveRequestService.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveRequestService.java
@@ -41,5 +41,5 @@ public interface ILeaveRequestService {
      * Employee-only: updates a pending own leave request's dates and reason.
      */
     boolean updatePendingForEmployee(int leaveId, User employee, LocalDate startDate, LocalDate endDate,
-            String reason);
+            String reason, Integer leaveTypeId);
 }

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveTypeService.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/ILeaveTypeService.java
@@ -1,0 +1,31 @@
+package nhom13.vn.service;
+
+import java.util.List;
+
+import nhom13.vn.entity.LeaveType;
+
+public interface ILeaveTypeService {
+
+    void ensureSystemDefaults();
+
+    List<LeaveType> findAll();
+
+    List<LeaveType> findAllActive();
+
+    LeaveType findById(int id);
+
+    LeaveType findByCode(String code);
+
+    void create(LeaveType leaveType);
+
+    /**
+     * Updates configuration. When {@link LeaveType#CODE_ANNUAL} {@code defaultDaysPerYear} changes,
+     * all {@link nhom13.vn.entity.LeaveBalance} rows are adjusted to keep {@code remaining = total - used}.
+     */
+    void update(LeaveType leaveType);
+
+    /**
+     * @return {@code false} when the type is referenced by any leave request
+     */
+    boolean deleteById(int id);
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveBalanceServiceImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveBalanceServiceImpl.java
@@ -3,20 +3,25 @@ package nhom13.vn.service.impl;
 import java.time.LocalDate;
 
 import nhom13.vn.dao.ILeaveBalanceDao;
+import nhom13.vn.dao.ILeaveTypeDao;
 import nhom13.vn.dao.impl.LeaveBalanceDaoImpl;
+import nhom13.vn.dao.impl.LeaveTypeDaoImpl;
 import nhom13.vn.entity.LeaveBalance;
+import nhom13.vn.entity.LeaveType;
 import nhom13.vn.entity.User;
 import nhom13.vn.service.ILeaveBalanceService;
 
 public class LeaveBalanceServiceImpl implements ILeaveBalanceService {
 
-    private static final int DEFAULT_LEAVE_DAYS = 12;
+    private static final int FALLBACK_ANNUAL_DAYS = 12;
     private static LeaveBalanceServiceImpl instance;
 
     private final ILeaveBalanceDao leaveBalanceDao;
+    private final ILeaveTypeDao leaveTypeDao;
 
     private LeaveBalanceServiceImpl() {
         this.leaveBalanceDao = new LeaveBalanceDaoImpl();
+        this.leaveTypeDao = new LeaveTypeDaoImpl();
     }
 
     public static LeaveBalanceServiceImpl getInstance() {
@@ -47,11 +52,13 @@ public class LeaveBalanceServiceImpl implements ILeaveBalanceService {
             return existing;
         }
 
+        int defaultDays = resolveDefaultAnnualDays();
+
         LeaveBalance leaveBalance = new LeaveBalance();
         leaveBalance.setUser(user);
-        leaveBalance.setTotalDays(DEFAULT_LEAVE_DAYS);
+        leaveBalance.setTotalDays(defaultDays);
         leaveBalance.setUsedDays(0);
-        leaveBalance.setRemainingDays(DEFAULT_LEAVE_DAYS);
+        leaveBalance.setRemainingDays(defaultDays);
         leaveBalance.setLastResetYear(LocalDate.now().getYear());
 
         leaveBalanceDao.insert(leaveBalance);
@@ -75,6 +82,19 @@ public class LeaveBalanceServiceImpl implements ILeaveBalanceService {
         leaveBalance.setTotalDays(usedDays + remainingDays);
 
         leaveBalanceDao.update(leaveBalance);
+    }
+
+    @Override
+    public void applyAnnualPolicyDayDelta(int delta) {
+        leaveBalanceDao.applyAnnualPolicyDayDelta(delta);
+    }
+
+    private int resolveDefaultAnnualDays() {
+        LeaveType annual = leaveTypeDao.findByCode(LeaveType.CODE_ANNUAL);
+        if (annual != null && annual.getDefaultDaysPerYear() > 0) {
+            return annual.getDefaultDaysPerYear();
+        }
+        return FALLBACK_ANNUAL_DAYS;
     }
 }
 

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveRequestServiceImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveRequestServiceImpl.java
@@ -179,7 +179,7 @@ public class LeaveRequestServiceImpl implements ILeaveRequestService {
 
     @Override
     public boolean updatePendingForEmployee(int leaveId, User employee, LocalDate startDate, LocalDate endDate,
-            String reason) {
+            String reason, Integer leaveTypeId) {
         if (employee == null || leaveId <= 0 ) {
             return false;
         }
@@ -195,7 +195,7 @@ public class LeaveRequestServiceImpl implements ILeaveRequestService {
             return false;
         }
         return dao.updatePendingForUser(leaveId, employee.getId(), Date.valueOf(startDate), Date.valueOf(endDate),
-                reason.trim());
+                reason.trim(), leaveTypeId);
     }
 
     private String normalizeStatus(String status) {

--- a/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveTypeServiceImpl.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/service/impl/LeaveTypeServiceImpl.java
@@ -1,0 +1,144 @@
+package nhom13.vn.service.impl;
+
+import java.util.List;
+
+import nhom13.vn.dao.ILeaveTypeDao;
+import nhom13.vn.dao.impl.LeaveTypeDaoImpl;
+import nhom13.vn.entity.LeaveType;
+import nhom13.vn.service.ILeaveBalanceService;
+import nhom13.vn.service.ILeaveTypeService;
+
+public class LeaveTypeServiceImpl implements ILeaveTypeService {
+
+    private static final int FALLBACK_ANNUAL_DAYS = 12;
+
+    private static LeaveTypeServiceImpl instance;
+
+    private final ILeaveTypeDao leaveTypeDao;
+    private final ILeaveBalanceService leaveBalanceService;
+
+    private LeaveTypeServiceImpl() {
+        this.leaveTypeDao = new LeaveTypeDaoImpl();
+        this.leaveBalanceService = LeaveBalanceServiceImpl.getInstance();
+    }
+
+    public static LeaveTypeServiceImpl getInstance() {
+        if (instance == null) {
+            instance = new LeaveTypeServiceImpl();
+        }
+        return instance;
+    }
+
+    @Override
+    public void ensureSystemDefaults() {
+        upsertDefaultIfMissing(LeaveType.CODE_ANNUAL, "Nghỉ phép năm", true, FALLBACK_ANNUAL_DAYS);
+        upsertDefaultIfMissing("SICK", "Nghỉ ốm", false, 0);
+        upsertDefaultIfMissing("UNPAID", "Nghỉ không lương", false, 0);
+    }
+
+    private void upsertDefaultIfMissing(String code, String name, boolean consumesBalance, int defaultDaysPerYear) {
+        LeaveType existing = leaveTypeDao.findByCode(code);
+        if (existing != null) {
+            return;
+        }
+        LeaveType lt = new LeaveType();
+        lt.setCode(code.trim().toUpperCase());
+        lt.setName(name);
+        lt.setConsumesBalance(consumesBalance);
+        lt.setDefaultDaysPerYear(Math.max(0, defaultDaysPerYear));
+        lt.setActive(true);
+        leaveTypeDao.insert(lt);
+    }
+
+    @Override
+    public List<LeaveType> findAll() {
+        return leaveTypeDao.findAllOrderByCode();
+    }
+
+    @Override
+    public List<LeaveType> findAllActive() {
+        return leaveTypeDao.findAllActiveOrderByCode();
+    }
+
+    @Override
+    public LeaveType findById(int id) {
+        return leaveTypeDao.findById(id);
+    }
+
+    @Override
+    public LeaveType findByCode(String code) {
+        return leaveTypeDao.findByCode(code);
+    }
+
+    @Override
+    public void create(LeaveType leaveType) {
+        if (leaveType == null) {
+            throw new IllegalArgumentException("leaveType is required");
+        }
+        String code = normalizeCode(leaveType.getCode());
+        leaveType.setCode(code);
+        if (leaveTypeDao.findByCode(code) != null) {
+            throw new IllegalStateException("Leave type code already exists: " + code);
+        }
+        if (leaveType.getName() == null || leaveType.getName().isBlank()) {
+            throw new IllegalArgumentException("Name is required");
+        }
+        leaveType.setName(leaveType.getName().trim());
+        if (leaveType.getDefaultDaysPerYear() < 0) {
+            leaveType.setDefaultDaysPerYear(0);
+        }
+        leaveTypeDao.insert(leaveType);
+    }
+
+    @Override
+    public void update(LeaveType incoming) {
+        if (incoming == null || incoming.getId() <= 0) {
+            throw new IllegalArgumentException("Invalid leave type");
+        }
+        LeaveType existing = leaveTypeDao.findById(incoming.getId());
+        if (existing == null) {
+            throw new IllegalStateException("Leave type not found");
+        }
+
+        int previousAnnualDays = existing.getDefaultDaysPerYear();
+        boolean isAnnual = LeaveType.CODE_ANNUAL.equalsIgnoreCase(existing.getCode());
+
+        if (incoming.getName() == null || incoming.getName().isBlank()) {
+            throw new IllegalArgumentException("Name is required");
+        }
+        existing.setName(incoming.getName().trim());
+        existing.setConsumesBalance(incoming.isConsumesBalance());
+        int newDefaultDays = Math.max(0, incoming.getDefaultDaysPerYear());
+        existing.setDefaultDaysPerYear(newDefaultDays);
+        existing.setActive(incoming.isActive());
+
+        leaveTypeDao.update(existing);
+
+        if (isAnnual && previousAnnualDays != newDefaultDays) {
+            leaveBalanceService.applyAnnualPolicyDayDelta(newDefaultDays - previousAnnualDays);
+        }
+    }
+
+    @Override
+    public boolean deleteById(int id) {
+        LeaveType existing = leaveTypeDao.findById(id);
+        if (existing == null) {
+            return false;
+        }
+        if (existing.isActive()) {
+            return false;
+        }
+        if (leaveTypeDao.countUsage(id) > 0) {
+            return false;
+        }
+        leaveTypeDao.delete(existing);
+        return true;
+    }
+
+    private static String normalizeCode(String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("Code is required");
+        }
+        return code.trim().toUpperCase();
+    }
+}

--- a/XinNghiPhep/src/main/java/nhom13/vn/utils/LeaveRequestBalanceUtil.java
+++ b/XinNghiPhep/src/main/java/nhom13/vn/utils/LeaveRequestBalanceUtil.java
@@ -1,0 +1,24 @@
+package nhom13.vn.utils;
+
+import nhom13.vn.entity.LeaveRequest;
+import nhom13.vn.entity.LeaveType;
+
+public final class LeaveRequestBalanceUtil {
+
+    private LeaveRequestBalanceUtil() {
+    }
+
+    /**
+     * Legacy rows without a {@link LeaveType} still consume the annual pool (backward compatible).
+     */
+    public static boolean consumesAnnualPool(LeaveRequest leaveRequest) {
+        if (leaveRequest == null) {
+            return false;
+        }
+        LeaveType type = leaveRequest.getLeaveType();
+        if (type == null) {
+            return true;
+        }
+        return type.isConsumesBalance();
+    }
+}

--- a/XinNghiPhep/src/main/resources/META-INF/persistence.xml
+++ b/XinNghiPhep/src/main/resources/META-INF/persistence.xml
@@ -17,7 +17,7 @@
 			<property name="jakarta.persistence.jdbc.user" value="sa" />
 
 			<property name="jakarta.persistence.jdbc.password"
-				value="1" />
+				value="123456" />
 
 			<property name="hibernate.show_sql" value="true" />
 

--- a/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/dashboard.jsp
@@ -33,6 +33,12 @@
 		</li>
 
 		<li>
+			<a href="${pageContext.request.contextPath}/admin/leave-types">
+				Manage Leave Types
+			</a>
+		</li>
+
+		<li>
 			<a href="${pageContext.request.contextPath}/admin/leave-statistics">
 				View Leave Statistics
 			</a>

--- a/XinNghiPhep/src/main/webapp/view/admin/leave-type-form.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/leave-type-form.jsp
@@ -1,0 +1,64 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Leave type</title>
+</head>
+<body>
+	<h2><c:choose><c:when test="${not empty leaveType}">Edit</c:when><c:otherwise>Add</c:otherwise></c:choose> leave type</h2>
+
+	<p><a href="${pageContext.request.contextPath}/admin/leave-types">Back to list</a></p>
+
+	<c:choose>
+		<c:when test="${not empty leaveType}">
+			<form method="post" action="${pageContext.request.contextPath}/admin/leave-types/update">
+				<input type="hidden" name="id" value="${leaveType.id}" />
+				<p>Code: <strong><c:out value="${leaveType.code}" /></strong> (cannot be changed)</p>
+				<p>Name: <input type="text" name="name" value="${leaveType.name}" required /></p>
+				<p>
+					<label>
+						<input type="checkbox" name="consumesBalance" ${leaveType.consumesBalance ? 'checked' : ''} />
+						Consumes annual leave balance
+					</label>
+				</p>
+				<p>
+					Default days / year:
+					<input type="number" name="defaultDaysPerYear" min="0" value="${leaveType.defaultDaysPerYear}" />
+					<small>(For code ANNUAL: new employee default and policy adjustments for all balances.)</small>
+				</p>
+				<p>
+					<label>
+						<input type="checkbox" name="active" ${leaveType.active ? 'checked' : ''} />
+						Active (shown when creating requests)
+					</label>
+				</p>
+				<button type="submit">Save</button>
+			</form>
+		</c:when>
+		<c:otherwise>
+			<form method="post" action="${pageContext.request.contextPath}/admin/leave-types/insert">
+				<p>Code: <input type="text" name="code" required maxlength="50" placeholder="e.g. MATERNITY" /></p>
+				<p>Name: <input type="text" name="name" required /></p>
+				<p>
+					<label>
+						<input type="checkbox" name="consumesBalance" />
+						Consumes annual leave balance
+					</label>
+				</p>
+				<p>
+					Default days / year: <input type="number" name="defaultDaysPerYear" min="0" value="0" />
+				</p>
+				<p>
+					<label>
+						<input type="checkbox" name="active" checked />
+						Active
+					</label>
+				</p>
+				<button type="submit">Create</button>
+			</form>
+		</c:otherwise>
+	</c:choose>
+</body>
+</html>

--- a/XinNghiPhep/src/main/webapp/view/admin/leave-types.jsp
+++ b/XinNghiPhep/src/main/webapp/view/admin/leave-types.jsp
@@ -1,0 +1,55 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Manage Leave Types</title>
+</head>
+<body>
+	<h2>Manage Leave Types</h2>
+
+	<c:if test="${not empty sessionScope.message}">
+		<p>${sessionScope.message}</p>
+		<c:remove var="message" scope="session" />
+	</c:if>
+
+	<p>
+		<a href="${pageContext.request.contextPath}/admin/dashboard">Admin dashboard</a> |
+		<a href="${pageContext.request.contextPath}/admin/leave-types/add">Add leave type</a>
+	</p>
+
+	<table border="1" cellpadding="6">
+		<tr>
+			<th>Code</th>
+			<th>Name</th>
+			<th>Consumes balance</th>
+			<th>Default days / year</th>
+			<th>Active</th>
+			<th></th>
+		</tr>
+		<c:forEach var="t" items="${list}">
+			<tr>
+				<td><c:out value="${t.code}" /></td>
+				<td><c:out value="${t.name}" /></td>
+				<td>${t.consumesBalance ? 'Yes' : 'No'}</td>
+				<td>${t.defaultDaysPerYear}</td>
+				<td>${t.active ? 'Yes' : 'No'}</td>
+				<td>
+					<a href="${pageContext.request.contextPath}/admin/leave-types/edit?id=${t.id}">Edit</a>
+					<c:choose>
+						<c:when test="${t.active}">
+							| <span style="color:#888;cursor:help" title="Tắt Active trước; sau đó mới xóa được (và không được có đơn nào dùng loại này).">Delete</span>
+						</c:when>
+						<c:otherwise>
+							|
+							<a href="${pageContext.request.contextPath}/admin/leave-types/delete?id=${t.id}"
+							   onclick="return confirm('Xóa loại nghỉ này? Chỉ được phép khi không còn đơn nào tham chiếu.');">Delete</a>
+						</c:otherwise>
+					</c:choose>
+				</td>
+			</tr>
+		</c:forEach>
+	</table>
+</body>
+</html>

--- a/XinNghiPhep/src/main/webapp/view/leave/create.jsp
+++ b/XinNghiPhep/src/main/webapp/view/leave/create.jsp
@@ -1,4 +1,4 @@
-<-- /view/leave/create.jsp -->
+<%-- /view/leave/create.jsp --%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 
@@ -21,6 +21,15 @@
 
 	<form method="post"
 		action="${pageContext.request.contextPath}/leave/insert">
+
+		Leave type:
+		<select name="leaveTypeId" required>
+			<option value="">-- Chọn --</option>
+			<c:forEach var="t" items="${leaveTypes}">
+				<option value="${t.id}"><c:out value="${t.name}" /> (${t.code})</option>
+			</c:forEach>
+		</select>
+		<br /><br />
 
 		Start Date: <input type="date" name="startDate" /> <br />
 		<br /> End Date: <input type="date" name="endDate" /> <br />

--- a/XinNghiPhep/src/main/webapp/view/leave/detail.jsp
+++ b/XinNghiPhep/src/main/webapp/view/leave/detail.jsp
@@ -34,6 +34,17 @@
 				<td>${leaveRequest.user.fullName}</td>
 			</tr>
 			<tr>
+				<th>Leave type</th>
+				<td>
+					<c:choose>
+						<c:when test="${leaveRequest.leaveType != null}">
+							<c:out value="${leaveRequest.leaveType.name}" /> (<c:out value="${leaveRequest.leaveType.code}" />)
+						</c:when>
+						<c:otherwise>— (legacy)</c:otherwise>
+					</c:choose>
+				</td>
+			</tr>
+			<tr>
 				<th>Start date</th>
 				<td>${leaveRequest.startDate}</td>
 			</tr>

--- a/XinNghiPhep/src/main/webapp/view/leave/edit.jsp
+++ b/XinNghiPhep/src/main/webapp/view/leave/edit.jsp
@@ -30,6 +30,17 @@
 			action="${pageContext.request.contextPath}/leave/update">
 			<input type="hidden" name="id" value="${leaveRequest.id}" />
 
+			Leave type:
+			<select name="leaveTypeId" required>
+				<c:forEach var="t" items="${leaveTypes}">
+					<option value="${t.id}"
+						<c:if test="${leaveRequest.leaveType != null && leaveRequest.leaveType.id == t.id}">selected="selected"</c:if>>
+						<c:out value="${t.name}" /> (${t.code})
+					</option>
+				</c:forEach>
+			</select>
+			<br /><br />
+
 			Start Date:
 			<input type="date" name="startDate" value="${startIso}" />
 			<br /><br />


### PR DESCRIPTION
## Summary
Implement leave type management feature for Super Admin.

## Changes
Add CRUD functionality for leave types
Super Admin can create, update, view, and delete leave types
Support configurable leave types such as annual, sick, and unpaid leave
Prevent deletion of leave types that are currently in use
Update leave balance correctly when leave type data is modified
Update DAO, Service, Controller layers
Add UI for managing leave types
Handle validation and error cases

## Testing
Super Admin can create a new leave type
Super Admin can update existing leave type information
Super Admin can view leave type list and details
- Super Admin cannot delete a leave type if it is currently being used
Leave balance updates correctly after leave type changes
UI updates correctly after CRUD actions
Data saved correctly in database

## Evidence
Verified in database (LeaveType / LeaveBalance related tables)

## Jira
ELMS-31
Closes #40 
